### PR TITLE
Experiment: cron disabled (log only)

### DIFF
--- a/cron/main.ts
+++ b/cron/main.ts
@@ -148,7 +148,13 @@ async function runAutomation() {
   }
 }
 
-// Deno.cronを使って1時間おきに実行
-Deno.cron("todoist-automation", "0 * * * *", runAutomation);
-
-console.log("Todoist automation service started - running every hour with Deno.cron");
+// デプロイ確認用: Cron登録を止めてログだけにする
+const enableCron = false;
+if (enableCron) {
+  Deno.cron("todoist-automation", "0 * * * *", runAutomation);
+  console.log(
+    "Todoist automation service started - running every hour with Deno.cron",
+  );
+} else {
+  console.log("Cron disabled for deploy test; no automation executed");
+}


### PR DESCRIPTION
Deno Deploy切り分け用の実験PRです。

- Cron登録を停止し、起動ログのみ出力する形に変更
- 既存処理は呼ばず、エントリーポイントはそのまま

Cronスケジュール実行が原因かどうかをCIで確認するためのブランチです。