### PR TITLE
Experiment: add HTTP entrypoint (cron disabled)

### DIFF
--- a/cron/main.ts
+++ b/cron/main.ts
@@ -148,7 +148,10 @@ async function runAutomation() {
   }
 }
 
-// Deno.cronを使って1時間おきに実行
-Deno.cron("todoist-automation", "0 * * * *", runAutomation);
-
-console.log("Todoist automation service started - running every hour with Deno.cron");
+Deno.serve(() =>
+  new Response("cron service http entrypoint (cron disabled)", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  })
+);
+console.log("HTTP entrypoint enabled; cron automation not scheduled");


### PR DESCRIPTION
Deno Deploy切り分け用の実験PRです。

- `Deno.serve` によるHTTPエントリポイントを追加し、cron登録は停止
- デプロイ時にHTTPワーカーとして動作する構成だけを確認

エントリポイント形態の差分（proxy と同様のHTTPハンドラ有無）が影響していないかをCIで確認するためのブランチです。