### PR TITLE
Experiment: tolerate missing TODOIST_TOKEN

### DIFF
--- a/cron/main.ts
+++ b/cron/main.ts
@@ -124,7 +124,8 @@ async function runAutomation() {
   try {
     const token = Deno.env.get("TODOIST_TOKEN");
     if (!token) {
-      throw new Error("TODOIST_TOKEN environment variable is required");
+      console.log("TODOIST_TOKEN not set; skipping automation run");
+      return;
     }
 
     console.log(`[${new Date().toISOString()}] Starting automation...`);


### PR DESCRIPTION
Deno Deploy切り分け用の実験PRです。

- `TODOIST_TOKEN` 未設定でも例外を投げず、ログを出してスキップするだけに変更
- Cronスケジュールは維持

環境変数必須の挙動がデプロイで落ちる原因かをCIで確認するためのブランチです。