### PR TITLE
Experiment: switch cron to setInterval

### DIFF
--- a/cron/deno.json
+++ b/cron/deno.json
@@ -5,8 +5,7 @@
   "compilerOptions": {
     "lib": [
       "deno.window",
-      "deno.ns",
-      "deno.unstable"
+      "deno.ns"
     ],
     "strict": true
   },
@@ -26,8 +25,8 @@
     "proseWrap": "preserve"
   },
   "tasks": {
-    "start": "deno run --allow-net --allow-env --allow-read --env --unstable-cron main.ts",
-    "dev": "deno run --allow-net --allow-env --allow-read --watch --env --unstable-cron main.ts",
+    "start": "deno run --allow-net --allow-env --allow-read --env main.ts",
+    "dev": "deno run --allow-net --allow-env --allow-read --watch --env main.ts",
     "debug": "deno run --allow-net --allow-env --allow-read --env debug.ts",
     "fmt": "deno fmt",
     "lint": "deno lint",

--- a/cron/main.ts
+++ b/cron/main.ts
@@ -148,7 +148,12 @@ async function runAutomation() {
   }
 }
 
-// Deno.cronを使って1時間おきに実行
-Deno.cron("todoist-automation", "0 * * * *", runAutomation);
+// setIntervalを使って1時間おきに実行
+await runAutomation();
+setInterval(() => {
+  runAutomation();
+}, 60 * 60 * 1000);
 
-console.log("Todoist automation service started - running every hour with Deno.cron");
+console.log(
+  "Todoist automation service started - running every hour with setInterval",
+);


### PR DESCRIPTION
Deno Deploy切り分け用の追加実験PRです。

- `Deno.cron` 依存を外し、`setInterval` で毎時実行に戻す
- `deno.json` から `deno.unstable` と `--unstable-cron` を削除

CIで setInterval 方式が通るか確認します。